### PR TITLE
Updated condition for Gold Label check and passing parameter name passing

### DIFF
--- a/spear/labeling/analysis/core.py
+++ b/spear/labeling/analysis/core.py
@@ -319,7 +319,8 @@ class LFAnalysis:
             lf_names = list(range(m))
 
         # Remap the true labels values
-        Y = np.array([self.mapping[v] for v in Y])
+        if Y is not None:
+            Y = np.array([self.mapping[v] for v in Y])
 
         # Default LF stats
         d["Polarity"] = Series(data=self.lf_polarities(), index=lf_names)
@@ -332,7 +333,7 @@ class LFAnalysis:
                 np.concatenate((Y.flatten(), self.L.flatten(), np.array([-1])))
             )
             confusions = [
-                confusion_matrix(Y, self.L[:, i], labels)[1:, 1:] for i in range(m)
+                confusion_matrix(Y, self.L[:, i], labels=labels)[1:, 1:] for i in range(m)
             ]
             corrects = [np.diagonal(conf).sum() for conf in confusions]
             incorrects = [


### PR DESCRIPTION
1. Current Version of Spear fails when we are trying to do LF analysis without passing Gold Labels and their values is passed as None and is causing the following error as it is not checked

Y = np.array([self.mapping[v] for v in Y])
TypeError: 'NoneType' object is not iterable


2. Also their is a function call of confusion_matrix in lf_summary method, which requires the parameter name to execute properly else it fails with following error of argument passing

confusion_matrix(Y, self.L[:, i], labels)[1:, 1:] for i in range(m)
TypeError: confusion_matrix() takes 2 positional arguments but 3 were given


The current code change fixes these two issues.